### PR TITLE
Fix for NextJS server rendering. Remove unnecessary async await in Treatment.tsx

### DIFF
--- a/src/components/Treatment/Treatment.tsx
+++ b/src/components/Treatment/Treatment.tsx
@@ -64,7 +64,7 @@ export const TreatmentFunction: FC<TreatmentFunctionProps> = ({
 
     context
       .ready()
-      .then(async () => {
+      .then(() => {
         //Turning the variable keys and values into an array of arrays
         const variablesArray = Object.keys(context.variableKeys()).map(
           (key) => [key, context.peekVariableValue(key)]
@@ -76,7 +76,7 @@ export const TreatmentFunction: FC<TreatmentFunctionProps> = ({
           {}
         );
 
-        const treatment = await context.treatment(name);
+        const treatment = context.treatment(name);
 
         // Setting the state
         setVariantAndVariables({


### PR DESCRIPTION
# Description
- Remove async await on line 79 as context.treatment() contains no async code. 
- This was preventing our application consuming this package from rendering VariantB correctly due to a promise being returned. 
- Our code was server rendering an experiment using a context created on the server and hydrated to the client without the need for a `<Loading>` component. 

# Verification
- We copied Treatment.tsx into our nextjs 12 app and made the same change to confirm it would render VariantB on the server and not default to VariantA then update to VariantB when run on the client. 
- We used a 0/100 split to force all users to see VariantB
- Code builds and tests pass

# Additional Context
- I work for Serko and we are communicating with members of your team. @calthejuggler has confirmed this would be a good change to make. 
- Image from Slack thread
![image](https://user-images.githubusercontent.com/24812747/207158660-6bcb0f7e-d24e-4436-8cbe-378de185ab5f.png)
