### PR TITLE
Removed another unnecessary async await

### DIFF
--- a/src/components/Treatment/Treatment.tsx
+++ b/src/components/Treatment/Treatment.tsx
@@ -131,8 +131,8 @@ export const Treatment: FC<TreatmentProps> = ({
 
     context
       .ready()
-      .then(async () => {
-        const treatment = await context.treatment(name);
+      .then(() => {
+        const treatment = context.treatment(name);
 
         // Setting the state
         setSelectedTreatment(


### PR DESCRIPTION
## Description

This PR removes a second `async/await` after being pointed out as unnecessary on `context.treatment()` by a member of **Serko**'s team.