### PR TITLE
Initialize selected treatment state with selected variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@absmartly/react-sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "homepage": "https://github.com/absmartly/react-sdk#README.md",
   "bugs": "https://github.com/absmartly/react-sdk/issues",
   "keywords": [

--- a/src/components/Treatment/Treatment.tsx
+++ b/src/components/Treatment/Treatment.tsx
@@ -117,10 +117,27 @@ export const Treatment: FC<TreatmentProps> = ({
     context && !context.isReady()
   );
 
+  // Turning the children array into objects and mapping them as variants
+  // and indexes
+  const childrenInfo = React.Children.map(children, (child, i) => {
+    const obj = child?.valueOf() as {
+      props: { variant: number | Char };
+    };
+    return { variant: obj.props.variant, index: i };
+  });
+
+  // Get the index of the first child with a variant matching the context treatment
+  const getSelectedChildIndex = (context: typeof absmartly.Context) => {
+    const treatment = context.treatment(name);
+    return childrenInfo?.filter(
+      (item) => convertLetterToNumber(item.variant) === (treatment || 0)
+    )[0]?.index;
+  };
+
   // The index of the selected variant in the children array
   const [selectedTreatment, setSelectedTreatment] = useState<
     number | undefined
-  >();
+  >(() => (context?.isReady() ? getSelectedChildIndex(context) : undefined));
 
   // Making the children prop into an array for selecting a single element later.
   const childrenArray = React.Children.toArray(children);
@@ -132,29 +149,14 @@ export const Treatment: FC<TreatmentProps> = ({
     context
       .ready()
       .then(() => {
-        const treatment = context.treatment(name);
-
         // Setting the state
-        setSelectedTreatment(
-          childrenInfo?.filter(
-            (item) => convertLetterToNumber(item.variant) === (treatment || 0)
-          )[0]?.index
-        );
+        setSelectedTreatment(getSelectedChildIndex(context));
       })
       .then(() => {
         setLoading(false);
       })
       .catch((e: Error) => console.error(e));
   }, [context]);
-
-  // Turning the children array into objects and mapping them as variants
-  // and indexes
-  const childrenInfo = React.Children.map(children, (child, i) => {
-    const obj = child?.valueOf() as {
-      props: { variant: number | Char };
-    };
-    return { variant: obj.props.variant, index: i };
-  });
 
   // Return the selected Treatment (Or treatment 0 or loading component)
   if (loading) {

--- a/tests/Treatment.spec.tsx
+++ b/tests/Treatment.spec.tsx
@@ -163,6 +163,7 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
     "should render treatment component %i by variant (%s)",
     async (variant, component) => {
       const TestComponent = jest.fn();
+      const ControlComponent = jest.fn();
       const TestLoadingComponent = jest.fn();
 
       const config = { a: 1, b: 2 };
@@ -178,7 +179,9 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
           context={mocks.context}
           name="test_exp"
         >
-          <TreatmentVariant variant="Z" />
+          <TreatmentVariant variant="Z">
+            <ControlComponent />
+          </TreatmentVariant>
           <TreatmentVariant variant={component as number | Char}>
             <TestComponent />
           </TreatmentVariant>
@@ -186,6 +189,7 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
       );
 
       await waitFor(() => {
+        expect(ControlComponent).toHaveBeenCalledTimes(0);
         expect(TestComponent).toHaveBeenCalledTimes(1);
       });
     }


### PR DESCRIPTION
We found that "selectedTreatment" state was not getting initialized with the selected treatment variant if the context is ready on the initial render. This was causing the component to re-render twice.

Specially, when the selected treatment variant is the second variant (B), it renders the default treatment variant on the initial render, and then re-renders with the second variant.

This PR will initialized the state with correct selected variant if the context has already been initialized and prevent the children from re-rendering twice.

Let me know if you have any other concerns with this PR.