### PR TITLE
Fixed javascript-sdk version to 1.11.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 /example
 /next-example
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@absmartly/react-sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "homepage": "https://github.com/absmartly/react-sdk#README.md",
   "bugs": "https://github.com/absmartly/react-sdk/issues",
   "keywords": [
@@ -49,7 +49,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
-    "@absmartly/javascript-sdk": "^1.10.0",
+    "@absmartly/javascript-sdk": "~1.11.0",
     "core-js": "^3.26.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,12 @@
 # yarn lockfile v1
 
 
-"@absmartly/javascript-sdk@^1.10.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@absmartly/javascript-sdk/-/javascript-sdk-1.11.0.tgz#5bac72ee3e6968217dd8dcfd29ee1ff3e005196e"
-  integrity sha512-+bX0Uw3OLCC78t2JsmddamrSW/pVN8zcfvaGGYMjOS4HBx1gIYV5bjxDRiNjrdARU59eKrHoXTGSLYF65NgwxQ==
+"@absmartly/javascript-sdk@~1.11.0":
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/@absmartly/javascript-sdk/-/javascript-sdk-1.11.7.tgz#03b0c61d7e08b2aa4869b1d69f2ad817b9514d31"
+  integrity sha512-0lAXYebYNZfg+h51ZzXHF9u9BKPrk2XGk3Aa3o2+WhRWe7XF0fiAk4HFAIz3SbwS1r9UYyZlE0Zm35YcSlTj7A==
   dependencies:
+    core-js "^3.20.0"
     node-fetch "^2.6.7"
     rfdc "^1.2.0"
 
@@ -1157,6 +1158,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+core-js@^3.20.0:
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.33.0.tgz#70366dbf737134761edb017990cf5ce6c6369c40"
+  integrity sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==
 
 core-js@^3.26.0:
   version "3.26.1"


### PR DESCRIPTION
This PR fixes the `@absmartly/javascript-sdk` to version `~1.11.0`. When newly updated, the React SDK was installing js-sdk `v1.12.1`. In that version of the Javascript SDK, we converted the codebase to Typescript. Because the React SDK is already written in TS, that caused some type breakages with some discrepancy between the type systems of the two packages.

The React SDK will be upgraded soon, but this should solve the problem for now.