### PR TITLE
bugfix/better context and SDK types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@absmartly/react-sdk",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "homepage": "https://github.com/absmartly/react-sdk#README.md",
   "bugs": "https://github.com/absmartly/react-sdk/issues",
   "keywords": [

--- a/src/components/SDKProvider/SDKProvider.tsx
+++ b/src/components/SDKProvider/SDKProvider.tsx
@@ -14,7 +14,7 @@ import { ABSmartly, ABSmartlyContext, ContextOptionsType, ContextRequestType, SD
 type SDKProviderNoContext = {
     sdkOptions: SDKOptionsType;
     context?: never;
-    contextOptions: Record<string, any>;
+    contextOptions: { units: Record<string, any> };
     children?: ReactNode;
 };
 
@@ -27,6 +27,7 @@ type SDKProviderWithContext = {
 
 type SDKProviderProps = SDKProviderNoContext | SDKProviderWithContext;
 
+// @ts-ignore
 const SDK = createContext<ABSmartly>({ sdk: undefined, context: undefined, resetContext: () => { } });
 
 export const SDKProvider: FC<SDKProviderProps> = ({

--- a/src/components/SDKProvider/SDKProvider.tsx
+++ b/src/components/SDKProvider/SDKProvider.tsx
@@ -27,8 +27,7 @@ type SDKProviderWithContext = {
 
 type SDKProviderProps = SDKProviderNoContext | SDKProviderWithContext;
 
-// @ts-ignore
-const SDK = createContext<ABSmartly>({ sdk: undefined, context: undefined, resetContext: () => { } });
+const SDK = createContext<ABSmartly | null>(null);
 
 export const SDKProvider: FC<SDKProviderProps> = ({
     sdkOptions,
@@ -93,4 +92,12 @@ export function withABSmartly<
     return ComponentWithABSmartly;
 }
 
-export const useABSmartly = () => useContext(SDK);
+export const useABSmartly = () => {
+    const sdk = useContext(SDK);
+
+    if (!sdk) {
+        throw new Error("useABSmartly must be used within an SDKProvider. https://docs.absmartly.com/docs/SDK-Documentation/getting-started#import-and-initialize-the-sdk");
+    }
+
+    return sdk;
+};

--- a/src/components/Treatment/Treatment.tsx
+++ b/src/components/Treatment/Treatment.tsx
@@ -6,7 +6,7 @@ import { convertLetterToNumber } from "../../utils/convertLetterToNumber";
 
 interface TreatmentFunctionProps {
   name: string;
-  context: typeof absmartly.Context;
+  context: absmartly.Context;
   attributes?: Record<string, unknown>;
   loadingComponent?: ReactNode;
   children(variantAndVariables: {
@@ -83,7 +83,7 @@ export const TreatmentFunction: FC<TreatmentFunctionProps> = ({
 
 interface TreatmentProps {
   name: string;
-  context: typeof absmartly.Context;
+  context: absmartly.Context;
   attributes?: Record<string, unknown>;
   loadingComponent?: ReactNode;
   children?: ReactNode;
@@ -109,7 +109,7 @@ export const Treatment: FC<TreatmentProps> = ({
   });
 
   // Get the index of the first child with a variant matching the context treatment
-  const getSelectedChildIndex = (context: typeof absmartly.Context) => {
+  const getSelectedChildIndex = (context: absmartly.Context) => {
     const treatment = context.treatment(name);
 
     const index = childrenInfo?.findIndex(

--- a/src/js-sdk.d.ts
+++ b/src/js-sdk.d.ts
@@ -1,1 +1,108 @@
-declare module "@absmartly/javascript-sdk";
+declare module "@absmartly/javascript-sdk" {
+  type EventNameType =
+    | "error"
+    | "ready"
+    | "refresh"
+    | "publish"
+    | "exposure"
+    | "goal"
+    | "finalize";
+
+  type ContextData = { experiments: Record<string, any>[] };
+
+  type ContextParams = {
+    units: Record<string, unknown>;
+  };
+
+  type ContextOptions = {
+    eventLogger?: (context: Context, eventName: string, data: any) => void;
+    refreshPeriod: number;
+    publishDelay: number;
+  };
+
+  type ClientRequestOptions = {
+    query?: Record<string, string | number | boolean>;
+    path: string;
+    method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
+    body?: Record<string, unknown>;
+    auth?: boolean;
+    timeout?: number;
+  };
+
+  type SDKOptions = {
+    eventLogger?: (context: Context, eventName: EventNameType, data: any) => void;
+  };
+
+  type ClientOptions = {
+    agent?: "javascript-client";
+    apiKey: string;
+    application: string | { name: string; version: number };
+    endpoint: string;
+    environment: string;
+    retries?: number;
+    timeout?: number;
+    keepalive?: boolean;
+  };
+
+  type Units = {
+    [key: string]: string | number;
+  };
+
+  type JSONPrimitive = string | number | boolean | null;
+  type JSONObject = { [key: string]: JSONValue };
+  type JSONArray = JSONValue[];
+  type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+
+  type CustomFieldValueType = "text" | "string" | "number" | "json" | "boolean";
+
+  export class SDK {
+    constructor(options: ClientOptions & SDKOptions);
+    getContextData(requestOptions: ClientRequestOptions): any;
+    createContext(params: ContextParams, options?: Partial<ContextOptions>, requestOptions?: Partial<ClientRequestOptions>): Context;
+    setEventLogger(logger: (context: Context, eventName: string, data: any) => void): void;
+    getEventLogger(): (context: Context, eventName: string, data: any) => void;
+    createContextWith(params: ContextParams, data: ContextData | Promise<ContextData>, options?: Partial<ContextOptions>): Context;
+  }
+
+  export class Context {
+    constructor(sdk: SDK, options: ContextOptions, params: ContextParams, promise: ContextData | Promise<ContextData>);
+    _sdk: SDK;
+    _opts: ContextOptions;
+    isReady(): boolean;
+    isFinalizing(): boolean;
+    isFinalized(): boolean;
+    isFailed(): boolean;
+    ready(): Promise<unknown>;
+    pending(): number;
+    data(): ContextData;
+    eventLogger(): (context: Context, eventName: string, data: any) => void;
+    publish(requestOptions?: ClientRequestOptions): Promise<void>;
+    refresh(requestOptions?: ClientRequestOptions): Promise<void>;
+    getUnit(unitType: string): string | number;
+    unit(unitType: string, uid: string | number): void;
+    getUnits(): Units;
+    units(units: Record<string, number | string>): void;
+    getAttribute(attrName: string): undefined;
+    attribute(attrName: string, value: unknown): void;
+    getAttributes(): Record<string, unknown>;
+    attributes(attrs: Record<string, unknown>): void;
+    peek(experimentName: string): number;
+    treatment(experimentName: string): number;
+    track(goalName: string, properties?: Record<string, unknown>): void;
+    finalize(requestOptions?: ClientRequestOptions): true | Promise<void>;
+    experiments(): string[] | undefined;
+    variableValue(key: string, defaultValue: string): string;
+    peekVariableValue(key: string, defaultValue: string): string;
+    variableKeys(): Record<string, unknown[]>;
+    override(experimentName: string, variant: number): void;
+    overrides(experimentVariants: Record<string, number>): void;
+    customAssignment(experimentName: string, variant: number): void;
+    customAssignments(experimentVariants: Record<string, number>): void;
+    customFieldKeys(): string[];
+    customFieldValue(experimentName: string, key: string): JSONValue;
+    customFieldValueType(experimentName: string, key: string): CustomFieldValueType | null;
+  }
+
+  export function mergeConfig(context: Context, previousConfig: Record<string, unknown>): any;
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,15 +10,15 @@ export type SDKOptionsType = {
     retries?: number;
     timeout?: number;
     eventLogger?: (
-        context: typeof absmartly.Context,
+        context: absmartly.Context,
         eventName: EventNameType,
         data: any
     ) => void;
 };
 
-export type ABSmartlyContext = typeof absmartly.Context;
+export type ABSmartlyContext = absmartly.Context;
 
-export type ABSmartlySDK = typeof absmartly.SDK;
+export type ABSmartlySDK = absmartly.SDK;
 
 export type ABSmartly = {
     sdk: ABSmartlySDK;

--- a/tests/SDKProvider.spec.tsx
+++ b/tests/SDKProvider.spec.tsx
@@ -18,24 +18,29 @@ const mockContextData = {
   experiments: [],
 };
 
+const mockContext = {
+} as Context;
+
 const mockCreateContext = jest.fn().mockImplementation(() => {
   return {
-    ...new Context(),
+    ...new Context({
+    } as SDK, { publishDelay: 5, refreshPeriod: 3000 }, { units: { user_id: "test_unit" } }, mockContextData),
     data: jest.fn().mockReturnValue(mockContextData),
   };
 });
 
 const mockCreateContextWith = jest.fn().mockImplementation(() => {
-  return new Context();
+  return new Context({
+  } as SDK, { publishDelay: 5, refreshPeriod: 3000 }, { units: { user_id: "test_unit" } }, mockContextData)
 });
 
-SDK.mockImplementation(() => {
+(SDK as jest.MockedClass<typeof SDK>).mockImplementation(() => {
   return {
     createContext: mockCreateContext,
     createContextWith: mockCreateContextWith,
     attributes: jest.fn().mockImplementation(),
     overrides: jest.fn().mockImplementation(),
-  };
+  } as unknown as SDK;
 });
 
 describe("SDKProvider", () => {
@@ -81,22 +86,22 @@ describe("SDKProvider", () => {
       </SDKProvider>
     );
 
-    expect(SDK).toBeCalledTimes(1);
+    expect(SDK).toHaveBeenCalledTimes(1);
     expect(SDK).toHaveBeenLastCalledWith(sdkOptions);
 
-    expect(mockCreateContext).toBeCalledTimes(1);
+    expect(mockCreateContext).toHaveBeenCalledTimes(1);
     expect(mockCreateContext).toHaveBeenLastCalledWith(contextOptions);
   });
 
   test("Whether it will create an SDK instance with a context that has prefetched context data", async () => {
     render(
-      <SDKProvider context={mockContextData}>
+      <SDKProvider context={mockContext}>
         <TestComponent />
       </SDKProvider>
     );
 
-    expect(SDK).not.toBeCalled();
-    expect(mockCreateContext).not.toBeCalled();
+    expect(SDK).not.toHaveBeenCalled();
+    expect(mockCreateContext).not.toHaveBeenCalled();
   });
 
   test("Whether useABSmartly hook works", async () => {

--- a/tests/SDKProvider.spec.tsx
+++ b/tests/SDKProvider.spec.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FC, PropsWithChildren } from "react";
 import "@testing-library/jest-dom";
 import {
   act,
@@ -104,11 +104,24 @@ describe("SDKProvider", () => {
     expect(mockCreateContext).not.toHaveBeenCalled();
   });
 
-  test("Whether useABSmartly hook works", async () => {
-    const { result } = renderHook(() => useABSmartly());
+  test("Whether useABSmartly throws an error when not used within an SDKProvider", async () => {
+    expect(() => renderHook(() => useABSmartly())).toThrow(
+      "useABSmartly must be used within an SDKProvider. https://docs.absmartly.com/docs/SDK-Documentation/getting-started#import-and-initialize-the-sdk"
+    );
+  })
 
-    expect(result.current.context).toBeUndefined();
-    expect(result.current.sdk).toBeUndefined();
+  test("Whether useABSmartly hook works", async () => {
+    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+      <SDKProvider sdkOptions={sdkOptions} contextOptions={contextOptions}>
+        {children}
+      </SDKProvider>
+    )
+    const { result } = renderHook(() => useABSmartly(), { wrapper });
+
+    expect(result.current.context).toBeDefined();
+    expect(result.current.sdk).toBeDefined();
+    expect(result.current.resetContext).toBeDefined();
+    expect(result.current.resetContext).toBeInstanceOf(Function);
   });
 
   test("resetContext function works as expected", async () => {

--- a/tests/Treatment.spec.tsx
+++ b/tests/Treatment.spec.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 
 import { Treatment, TreatmentFunction, TreatmentVariant } from "../src";
 import { Char, TreatmentProps } from "../src/types";
+import { Context } from "@absmartly/javascript-sdk";
 
 jest.mock("@absmartly/javascript-sdk");
 
@@ -17,7 +18,7 @@ const mocks = {
     isFailed: jest.fn(),
     variableKeys: jest.fn().mockReturnValue({ "button.color": "red" }),
     peekVariableValue: jest.fn(),
-  },
+  } as unknown as jest.Mocked<Context>,
 };
 
 describe("Treatment Component (TreatmentVariants as children)", () => {
@@ -25,13 +26,11 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
     const TestComponent = jest.fn();
     const TestLoadingComponent = jest.fn();
 
-    const config = { a: 1, b: 2 };
     const attributes = { attr1: 15, attr2: 50 };
 
     mocks.context.isReady.mockReturnValue(true);
     mocks.context.isFailed.mockReturnValue(false);
     mocks.context.treatment.mockReturnValue(1);
-    mocks.context.experimentConfig.mockReturnValue(config);
     mocks.context.ready.mockResolvedValue(true);
 
     render(
@@ -86,7 +85,6 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
 
     await waitFor(() => {
       expect(mocks.context.treatment).not.toHaveBeenCalled();
-      expect(mocks.context.experimentConfig).not.toHaveBeenCalled();
       expect(mocks.context.attributes).not.toHaveBeenCalled();
       expect(TestTreatmentVariant).not.toHaveBeenCalled();
       expect(TestLoadingComponent).toHaveBeenCalledTimes(1);
@@ -119,7 +117,6 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
     );
 
     expect(mocks.context.treatment).not.toHaveBeenCalled();
-    expect(mocks.context.experimentConfig).not.toHaveBeenCalled();
     expect(mocks.context.attributes).not.toHaveBeenCalled();
     expect(TestComponent).toHaveBeenCalledTimes(1);
 
@@ -130,7 +127,6 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
     const config = { a: 1, b: 2 };
     mocks.context.isReady.mockReturnValue(true);
     mocks.context.treatment.mockReturnValue(1);
-    mocks.context.experimentConfig.mockReturnValue(config);
 
     ready.then(async () => {
       await waitFor(() => {
@@ -162,12 +158,10 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
       const ControlComponent = jest.fn();
       const TestLoadingComponent = jest.fn();
 
-      const config = { a: 1, b: 2 };
 
       mocks.context.isReady.mockReturnValue(true);
       mocks.context.isFailed.mockReturnValue(false);
       mocks.context.treatment.mockReturnValue(variant);
-      mocks.context.experimentConfig.mockReturnValue(config);
 
       render(
         <Treatment
@@ -203,12 +197,9 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
       const TestComponent = jest.fn();
       const TestLoadingComponent = jest.fn();
 
-      const config = { a: 1, b: 2 };
-
       mocks.context.isReady.mockReturnValue(true);
       mocks.context.isFailed.mockReturnValue(false);
       mocks.context.treatment.mockReturnValue(variant);
-      mocks.context.experimentConfig.mockReturnValue(config);
 
       render(
         <Treatment
@@ -234,7 +225,6 @@ describe("Treatment Component (TreatmentVariants as children)", () => {
     mocks.context.isReady.mockReturnValue(true);
     mocks.context.isFailed.mockReturnValue(false);
     mocks.context.treatment.mockReturnValue(1);
-    mocks.context.experimentConfig.mockReturnValue({});
 
     render(
       <Treatment context={mocks.context} name="test_exp">
@@ -271,13 +261,11 @@ describe("TreatmentFunction Component", () => {
     const TestComponent2 = jest.fn();
     const TestLoadingComponent = jest.fn();
 
-    const config = { a: 1, b: 2 };
     const attributes = { attr1: 15, attr2: 50 };
 
     mocks.context.isReady.mockReturnValue(true);
     mocks.context.isFailed.mockReturnValue(false);
     mocks.context.treatment.mockReturnValue(1);
-    mocks.context.experimentConfig.mockReturnValue(config);
     mocks.context.ready.mockResolvedValue(true);
 
     render(
@@ -332,7 +320,6 @@ describe("TreatmentFunction Component", () => {
 
     await waitFor(() => {
       expect(mocks.context.treatment).not.toHaveBeenCalled();
-      expect(mocks.context.experimentConfig).not.toHaveBeenCalled();
       expect(mocks.context.attributes).not.toHaveBeenCalled();
       expect(TestComponent).not.toHaveBeenCalled();
       expect(TestLoadingComponent).toHaveBeenCalledTimes(1);
@@ -341,7 +328,6 @@ describe("TreatmentFunction Component", () => {
     const config = { a: 1, b: 2 };
     mocks.context.isReady.mockReturnValue(true);
     mocks.context.treatment.mockReturnValue(1);
-    mocks.context.experimentConfig.mockReturnValue(config);
 
     ready.then(async () => {
       await waitFor(() => {
@@ -386,7 +372,6 @@ describe("TreatmentFunction Component", () => {
     );
 
     expect(mocks.context.treatment).not.toHaveBeenCalled();
-    expect(mocks.context.experimentConfig).not.toHaveBeenCalled();
     expect(mocks.context.attributes).not.toHaveBeenCalled();
     expect(TestComponent).toHaveBeenCalledTimes(1);
     expect(TestComponentThatShouldntRender).not.toHaveBeenCalled();
@@ -398,7 +383,6 @@ describe("TreatmentFunction Component", () => {
     const config = { a: 1, b: 2 };
     mocks.context.isReady.mockReturnValue(true);
     mocks.context.treatment.mockReturnValue(1);
-    mocks.context.experimentConfig.mockReturnValue(config);
 
     ready.then(async () => {
       await waitFor(() => {
@@ -424,12 +408,9 @@ describe("TreatmentFunction Component", () => {
       const TestComponent = jest.fn();
       const TestLoadingComponent = jest.fn();
 
-      const config = { a: 1, b: 2 };
-
       mocks.context.isReady.mockReturnValue(true);
       mocks.context.isFailed.mockReturnValue(false);
       mocks.context.treatment.mockReturnValue(variant);
-      mocks.context.experimentConfig.mockReturnValue(config);
 
       render(
         <TreatmentFunction

--- a/tests/js-sdk.d.ts
+++ b/tests/js-sdk.d.ts
@@ -1,1 +1,108 @@
-declare module "@absmartly/javascript-sdk";
+declare module "@absmartly/javascript-sdk" {
+  type EventNameType =
+    | "error"
+    | "ready"
+    | "refresh"
+    | "publish"
+    | "exposure"
+    | "goal"
+    | "finalize";
+
+  type ContextData = { experiments: Record<string, any>[] };
+
+  type ContextParams = {
+    units: Record<string, unknown>;
+  };
+
+  type ContextOptions = {
+    eventLogger?: (context: Context, eventName: string, data: any) => void;
+    refreshPeriod: number;
+    publishDelay: number;
+  };
+
+  type ClientRequestOptions = {
+    query?: Record<string, string | number | boolean>;
+    path: string;
+    method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
+    body?: Record<string, unknown>;
+    auth?: boolean;
+    timeout?: number;
+  };
+
+  type SDKOptions = {
+    eventLogger?: (context: Context, eventName: EventNameType, data: any) => void;
+  };
+
+  type ClientOptions = {
+    agent?: "javascript-client";
+    apiKey: string;
+    application: string | { name: string; version: number };
+    endpoint: string;
+    environment: string;
+    retries?: number;
+    timeout?: number;
+    keepalive?: boolean;
+  };
+
+  type Units = {
+    [key: string]: string | number;
+  };
+
+  type JSONPrimitive = string | number | boolean | null;
+  type JSONObject = { [key: string]: JSONValue };
+  type JSONArray = JSONValue[];
+  type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+
+  type CustomFieldValueType = "text" | "string" | "number" | "json" | "boolean";
+
+  export class SDK {
+    constructor(options: ClientOptions & SDKOptions);
+    getContextData(requestOptions: ClientRequestOptions): any;
+    createContext(params: ContextParams, options?: Partial<ContextOptions>, requestOptions?: Partial<ClientRequestOptions>): Context;
+    setEventLogger(logger: (context: Context, eventName: string, data: any) => void): void;
+    getEventLogger(): (context: Context, eventName: string, data: any) => void;
+    createContextWith(params: ContextParams, data: ContextData | Promise<ContextData>, options?: Partial<ContextOptions>): Context;
+  }
+
+  export class Context {
+    constructor(sdk: SDK, options: ContextOptions, params: ContextParams, promise: ContextData | Promise<ContextData>);
+    _sdk: SDK;
+    _opts: ContextOptions;
+    isReady(): boolean;
+    isFinalizing(): boolean;
+    isFinalized(): boolean;
+    isFailed(): boolean;
+    ready(): Promise<unknown>;
+    pending(): number;
+    data(): ContextData;
+    eventLogger(): (context: Context, eventName: string, data: any) => void;
+    publish(requestOptions?: ClientRequestOptions): Promise<void>;
+    refresh(requestOptions?: ClientRequestOptions): Promise<void>;
+    getUnit(unitType: string): string | number;
+    unit(unitType: string, uid: string | number): void;
+    getUnits(): Units;
+    units(units: Record<string, number | string>): void;
+    getAttribute(attrName: string): undefined;
+    attribute(attrName: string, value: unknown): void;
+    getAttributes(): Record<string, unknown>;
+    attributes(attrs: Record<string, unknown>): void;
+    peek(experimentName: string): number;
+    treatment(experimentName: string): number;
+    track(goalName: string, properties?: Record<string, unknown>): void;
+    finalize(requestOptions?: ClientRequestOptions): true | Promise<void>;
+    experiments(): string[] | undefined;
+    variableValue(key: string, defaultValue: string): string;
+    peekVariableValue(key: string, defaultValue: string): string;
+    variableKeys(): Record<string, unknown[]>;
+    override(experimentName: string, variant: number): void;
+    overrides(experimentVariants: Record<string, number>): void;
+    customAssignment(experimentName: string, variant: number): void;
+    customAssignments(experimentVariants: Record<string, number>): void;
+    customFieldKeys(): string[];
+    customFieldValue(experimentName: string, key: string): JSONValue;
+    customFieldValueType(experimentName: string, key: string): CustomFieldValueType | null;
+  }
+
+  export function mergeConfig(context: Context, previousConfig: Record<string, unknown>): any;
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,6 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "lib"]
+  "exclude": ["node_modules", "lib"],
+  "typeRoots": ["node_modules/@types", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
This PR adds better type declarations for the Javascript SDK, allowing for the use of the classes' methods and properties in a more predictable way. It also improves the `useABsmartly` hook by throwing an error when used outside of an SDKProvider. Lastly, it updates some of our tests to use newer `ts-jest` best practices.
