### PR TITLE
feature/add useTreatment hook

### DIFF
--- a/src/hooks/useTreatment.ts
+++ b/src/hooks/useTreatment.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { useABSmartly } from "../components/SDKProvider";
+
+export const useTreatment = (name: string, peek = false) => {
+  const { context } = useABSmartly();
+
+  const [variant, setVariant] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchTreatment = async () => {
+      try {
+        await context.ready();
+        const treatment = peek ? context.peek(name) : context.treatment(name);
+        setVariant(treatment);
+      } catch (error) {
+        setError(error instanceof Error ? error : new Error(error.toString()));
+        console.error("Failed to get variant: ", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTreatment();
+  }, [context, name, peek]);
+
+  return { variant, loading, error, context };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   Treatment,
   TreatmentVariant,
 } from "./components/Treatment";
+import { useTreatment } from "./hooks/useTreatment";
 import { mergeConfig } from "@absmartly/javascript-sdk";
 import {
   ABSmartly,
@@ -27,6 +28,7 @@ export {
   TreatmentVariant,
   useABSmartly,
   withABSmartly,
+  useTreatment,
 };
 
 export default SDKProvider;

--- a/tests/useTreatment.spec.ts
+++ b/tests/useTreatment.spec.ts
@@ -1,0 +1,85 @@
+import { Context, SDK } from "@absmartly/javascript-sdk";
+import { useABSmartly, useTreatment } from "../src";
+
+import { renderHook, waitFor } from "@testing-library/react";
+
+jest.mock("../src/components/SDKProvider");
+
+const mockedUseABSmartly = useABSmartly as jest.MockedFunction<
+  typeof useABSmartly
+>;
+
+describe("useTreatment", () => {
+  const mockContext = {
+    ready: jest.fn(),
+    peek: jest.fn(),
+    treatment: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockedUseABSmartly.mockReturnValue({
+      context: mockContext as unknown as Context,
+      sdk: null as unknown as SDK,
+      resetContext: () => {},
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return variant after context is ready", async () => {
+    mockContext.ready.mockResolvedValueOnce(undefined);
+    mockContext.treatment.mockReturnValueOnce(1);
+
+    const { result } = renderHook(() => useTreatment("experiment-name"));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.variant).toBe(null);
+    expect(result.current.error).toBe(null);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.variant).toBe(1);
+      expect(result.current.error).toBe(null);
+    });
+  });
+
+  test("should handle errors correctly", async () => {
+    const error = new Error("Test error");
+    mockContext.ready.mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useTreatment("experiment-name"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.variant).toBe(null);
+      expect(result.current.error).toBe(error);
+    });
+  });
+
+  test("should use peek when specified", async () => {
+    mockContext.ready.mockResolvedValueOnce(undefined);
+    mockContext.peek.mockReturnValueOnce(2);
+
+    const { result } = renderHook(() => useTreatment("experiment-name", true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.variant).toBe(2);
+      expect(result.current.error).toBe(null);
+    });
+  });
+
+  test("should handle non-error objects in catch", async () => {
+    mockContext.ready.mockRejectedValueOnce("Test error");
+
+    const { result } = renderHook(() => useTreatment("experiment-name"));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.variant).toBe(null);
+      expect(result.current.error?.message).toBe("Test error");
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `useTreatment` hook to the SDK, as inspired by @caal-15. The hook simply returns the variant for a particular experiment, the current loading state, an error if present (or null), and the currently used context.