### PR TITLE
fix: use immediate treatment if available

### DIFF
--- a/src/hooks/useTreatment.ts
+++ b/src/hooks/useTreatment.ts
@@ -4,12 +4,19 @@ import { useABSmartly } from "./useABSmartly";
 export const useTreatment = (name: string, peek = false) => {
   const { context } = useABSmartly();
 
-  const [variant, setVariant] = useState<number | null>(null);
-  const [loading, setLoading] = useState(true);
+  const isReady = context != null && context.isReady();
+
+  const [variant, setVariant] = useState<number | null>(
+    isReady ? (peek ? context.peek(name) : context.treatment(name)) : null,
+  );
+  const [loading, setLoading] = useState(context == null || !context.isReady());
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    if (variant != null) return;
+
     const fetchTreatment = async () => {
+      if (context == null) return;
       try {
         await context.ready();
         const treatment = peek ? context.peek(name) : context.treatment(name);

--- a/tests/useTreatment.test.ts
+++ b/tests/useTreatment.test.ts
@@ -20,6 +20,7 @@ const mockContext = {
   ready: vi.fn(),
   peek: vi.fn(),
   treatment: vi.fn(),
+  isReady: vi.fn(),
 };
 
 beforeEach(() => {


### PR DESCRIPTION
This PR makes it so that if the context is already ready when `useTreatment` is called, the treatment is used immediately instead of being instantiated as `null` and set in a `useEffect`